### PR TITLE
Image now stored in bytes and removed non-async URL calls.

### DIFF
--- a/models/contributor.py
+++ b/models/contributor.py
@@ -1,6 +1,6 @@
 # Imports.
-import io
 import requests
+from io import BytesIO
 from typing import Dict
 
 from PIL import Image
@@ -37,10 +37,7 @@ class Contributor:
     def __str__(self) -> str:
         return f'Top contributor of {self.org}: {self.login} | {self.html_url}'
 
-    def generate_avatar(
-        self,
-        file_name: str | None = None,
-    ) -> Image:
+    def generate_avatar(self) -> Image:
         '''
         Generates the avatar image of the contributor in a seeable format.
 
@@ -52,7 +49,7 @@ class Contributor:
         '''
 
         response = requests.get(self.avatar_url)
-        image_bytes = io.BytesIO(response.content)
+        image_bytes = BytesIO(response.content)
 
         image = Image.open(image_bytes)
         return image

--- a/models/contributor.py
+++ b/models/contributor.py
@@ -1,8 +1,8 @@
 # Imports.
-import requests
 from io import BytesIO
 from typing import Dict
 
+import aiohttp
 from PIL import Image
 
 from .organization import Organization
@@ -37,7 +37,7 @@ class Contributor:
     def __str__(self) -> str:
         return f'Top contributor of {self.org}: {self.login} | {self.html_url}'
 
-    def generate_avatar(self) -> Image:
+    async def generate_avatar(self) -> Image:
         '''
         Generates the avatar image of the contributor in a seeable format.
 
@@ -48,8 +48,9 @@ class Contributor:
             An Image object.
         '''
 
-        response = requests.get(self.avatar_url)
-        image_bytes = BytesIO(response.content)
+        async with aiohttp.ClientSession() as session:
+            async with session.get(self.avatar_url) as response:
+                image_bytes = BytesIO(await response.read())
 
         image = Image.open(image_bytes)
         return image

--- a/models/contributor.py
+++ b/models/contributor.py
@@ -1,5 +1,6 @@
 # Imports.
-import urllib.request
+import io
+import requests
 from typing import Dict
 
 from PIL import Image
@@ -50,10 +51,8 @@ class Contributor:
             An Image object.
         '''
 
-        if not file_name:
-            file_name = f'{self.id}.png'
+        response = requests.get(self.avatar_url)
+        image_bytes = io.BytesIO(response.content)
 
-        urllib.request.urlretrieve(self.avatar_url, file_name)
-
-        image = Image.open(file_name)
+        image = Image.open(image_bytes)
         return image

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ aiohttp==3.8.3
 aiosignal==1.2.0
 async-timeout==4.0.2
 attrs==22.1.0
-certifi==2022.9.24
 charset-normalizer==2.1.1
 flake8==5.0.4
 frozenlist==1.3.1
@@ -13,6 +12,4 @@ Pillow==9.2.0
 pycodestyle==2.9.1
 pyflakes==2.5.0
 python-dotenv==0.21.0
-requests==2.28.1
-urllib3==1.26.12
 yarl==1.8.1

--- a/src/bot.py
+++ b/src/bot.py
@@ -66,17 +66,17 @@ class Bot:
 
         async def wrapper(self):
             data = await self.get_data()
-            return func(self, data)
+            return await func(self, data)
 
         return wrapper
 
     @get_contributor_before_run
-    def show_avatar(self, contributor: Contributor) -> None:
+    async def show_avatar(self, contributor: Contributor) -> None:
         '''
         Shows the avatar of the top contributor.
         '''
 
-        image = contributor.generate_avatar()
+        image = await contributor.generate_avatar()
         image.show()
 
     def run(self) -> None:


### PR DESCRIPTION
### Things changed:

- [x] Images are now stored in the working memory instead of local storage using the built-in `io.BytesIO` method.
- [x] Removed the requirement for `urllib.request` and replaced with `aiohttp` for asynchronous calls.
- [x] Removed unused requirements from the frozen requirements text file.