### PR TITLE
refactor: add 'discord_webhook` to the dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ aiosignal==1.2.0
 async-timeout==4.0.2
 attrs==22.1.0
 charset-normalizer==2.1.1
+discord-webhook==0.17.0
 flake8==5.0.4
 frozenlist==1.3.1
 idna==3.4


### PR DESCRIPTION
A tiny tiny tiny fix because the docker build was failing :grin: 