### PR TITLE
chore: Bot runs once every startup; fixed type hints and more.

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,9 @@ from src.bot import Bot
 # Set `.env` TEST_MODE=true
 
 # Running the bot.
+
+# Set the run_at_start argument to False if you'd not like to optionally
+# execute tasks every time you start the bot.
 if __name__ == "__main__":
     bot = Bot()
-    # Pass the `run_at_start` argument to make the bot run at start
-    bot.run()
+    bot.run(run_at_start=True)

--- a/models/contributor.py
+++ b/models/contributor.py
@@ -155,7 +155,7 @@ class Contributor:
         webhook = DiscordWebhook(
             url=bot_settings.discord_hook,
             content="The top contributor of this month is "
-            + f"`{self.login}` with {self.pr_count} merged prs and {self.issue_count} opened issues.\n@everyone",
+            + f"`{self.login}` with {self.pr_count} merged prs and {self.issue_count} opened issues.",
         )
         webhook.add_file(file=self.image_bytes, filename="contributor.png")
         webhook.execute()

--- a/src/bot.py
+++ b/src/bot.py
@@ -15,7 +15,7 @@ class Bot:
     def __init__(self) -> None:
         pass
 
-    async def get_data(self) -> Any:
+    async def get_data(self) -> Contributor | None:
         """
         GET github data by making a simple request to GitHub's REST API.
         """
@@ -104,9 +104,11 @@ class Bot:
         contributors = sorted(
             contributors.items(), key=lambda x: x[1].pr_count, reverse=True
         )
+
         if contributors:
             return contributors[0][1]
-        return None
+        else:
+            return None
 
     def get_contributor_before_run(func) -> Any:
         """

--- a/src/bot.py
+++ b/src/bot.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import aiocron
 import aiohttp
-
 from models import Contributor, Organization
 
 from .global_ import bot_settings
@@ -121,7 +120,7 @@ class Bot:
         return wrapper
 
     @get_contributor_before_run
-    async def run_tasks(self, contributor: Contributor) -> None:
+    async def run_once(self, contributor: Contributor) -> None:
         """
         Shows the avatar of the top contributor.
         """
@@ -137,16 +136,14 @@ class Bot:
         else:
             logging.warning("No contributor for the given time period.")
 
-    async def run_once(self):
-        await self.run_tasks()
-
     @staticmethod
     @aiocron.crontab(f"0 0 */{bot_settings.time_period_days} * *")
-    async def every():
+    async def every() -> None:
         bot = Bot()
-        await bot.run_tasks()
+        await bot.run_once()
 
-    def run(self, run_at_start: bool = False) -> None:
+    def run(self, *, run_at_start: bool = False) -> None:
         if run_at_start:
             asyncio.run(self.run_once())
+
         asyncio.get_event_loop().run_forever()


### PR DESCRIPTION
### Things changed:

- [x] Bot now executes the tasks on each startup by default.
- [x] Fixed type hinting in `Bot.get_data()` and some other places.
- [x] No more pinging @everyone with the Discord webhook (thanks to Nishant for spotting this silly mistake) :P