### PR TITLE
refactor: Add image saving to test mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,5 +162,6 @@ cython_debug/
 # macOS
 .DS_Store
 
-#Hacksquad folder
+# Custom
 hacksquad/
+test_image.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Initialize Python 3.10 and set current directory.
-FROM python:3.10
+# Initialize Python 3.11 and set current directory.
+FROM python:3.11
 
 # Copy project files into working directory.
 COPY . /app/

--- a/models/contributor.py
+++ b/models/contributor.py
@@ -71,13 +71,11 @@ class Contributor:
 
         async with aiohttp.ClientSession() as session:
             async with session.get(self.avatar_url) as response:
-                avatar_bytes = BytesIO(await response.read())
-                avatar = Image.open(avatar_bytes).resize((200, 200))
+                avatar = Image.open(BytesIO(await response.read())).resize((200, 200))
                 image.paste(avatar, (500, 270))
 
-            async with session.get(self.organization.avatar_url) as response2:
-                org_avatar_bytes = BytesIO(await response2.read())
-                org_avatar = Image.open(org_avatar_bytes).resize((80, 80))
+            async with session.get(self.organization.avatar_url) as response:
+                org_avatar = Image.open(BytesIO(await response.read())).resize((80, 80))
 
                 bigsize = (org_avatar.size[0] * 3, org_avatar.size[1] * 3)
                 mask = Image.new("L", bigsize, 0)

--- a/src/bot.py
+++ b/src/bot.py
@@ -7,6 +7,7 @@ from typing import Any
 import aiocron
 import aiohttp
 from models import Contributor, Organization
+from PIL import Image
 
 from src import secrets
 
@@ -113,7 +114,11 @@ class Bot:
             except Exception as e:
                 logging.error("Cannot post to Discord or Twitter\nError: {}".format(e))
             else:
-                image.show()
+                file_name = "test_image.png"
+                image.save(file_name)
+
+                preview = Image.open(file_name)
+                preview.show()
 
         else:
             logging.warning("No contributor for the given time period.")


### PR DESCRIPTION
### Things changed:

This PR adds Python 3.11 as the base image for Docker and enables saving the image as a file on the physical storage while in test mode.